### PR TITLE
Fix missing QMediaPlayer include by linking QtMultimedia

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find the required Qt packages
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Widgets Multimedia)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets Multimedia)
 
 # Define source files
 set(SOURCES
@@ -106,6 +106,7 @@ target_link_libraries(CyberDom PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Multimedia
 )
 
 # Handle resources if any


### PR DESCRIPTION
## Summary
- add QtMultimedia to required Qt components
- link against QtMultimedia in the executable target

## Testing
- `cmake ..`
- `cmake --build .` *(fails: expected ‘;’ before ‘{’ token)*