### PR TITLE
Remove old parsing logic from CyberDom

### DIFF
--- a/ScriptData.h
+++ b/ScriptData.h
@@ -1273,6 +1273,7 @@ struct PopupGroupDefinition {
 struct ScriptData {
     GeneralSettings general;
     QMap<QString, QString> generalSettings;
+    QMap<QString, QMap<QString, QStringList>> rawSections;
     InitSettings init;
     EventSettings events;
     QMap<QString, StatusDefinition> statuses;

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -123,7 +123,6 @@ private:
     void initializeUiWithIniFile();
     void initializeProgressBarRange();
     void updateProgressBarValue();
-    void loadIniFile();
 
     // Get values from parsed script data
     QString getIniValue(const QString &section, const QString &key, const QString &defaultValue = "") const;

--- a/scriptparser.h
+++ b/scriptparser.h
@@ -4,12 +4,38 @@
 #include "ScriptData.h"
 #include <QString>
 #include <QMap>
+#include <QStringList>
+
+using StatusSection = StatusDefinition;
+using PunishmentSection = PunishmentDefinition;
+using JobSection = JobDefinition;
+using ClothTypeSection = ClothingTypeDefinition;
+using QuestionSection = QuestionDefinition;
 
 class ScriptParser {
 public:
     bool parseScript(const QString& path);
 
     const ScriptData& getScriptData() const { return scriptData; };
+
+    // Access parsed data
+    QStringList getRawSectionNames() const;
+    QMap<QString, QStringList> getRawSectionData(const QString &section) const;
+    QString getIniValue(const QString &section, const QString &key, const QString &defaultValue = QString()) const;
+
+    QString getMaster() const;
+    QString getSubName() const;
+    int getMinMerits() const;
+    int getMaxMerits() const;
+    bool isTestMenuEnabled() const;
+
+    QList<StatusDefinition> getStatusSections() const;
+    StatusDefinition getStatus(const QString &name) const;
+    QList<JobDefinition> getJobSections() const;
+    QList<PunishmentDefinition> getPunishmentSections() const;
+    QList<ClothingTypeDefinition> getClothTypeSections() const;
+    QuestionDefinition getQuestion(const QString &name) const;
+    void setVariable(const QString &name, const QString &value);
 
     void parseGeneralSection(const QString &sectionName, const QMap<QString, QStringList>& section);
     void parseInitSection(const QMap<QString, QStringList>& section);


### PR DESCRIPTION
## Summary
- remove deprecated loadIniFile function and its use
- drop unused processIniValue and parseAskPunishment methods
- simplify INI initialization to rely solely on ScriptParser
- clean up ChangeMerits dialog
- expand ScriptParser with getters and raw section storage

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt5Multimedia")*