### PR TITLE
Expose iniData in CyberDom

### DIFF
--- a/assignments.h
+++ b/assignments.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QListWidget>
+#include <QTableWidget>
 
 class CyberDom;
 

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -47,6 +47,8 @@ public:
     QSet<QString> assignedJobs;
     QSet<QString> getActiveJobs() { return activeAssignments; }
 
+    const QMap<QString, QMap<QString, QString>>& getIniData() const { return iniData; }
+
     QStringList getAvailableJobs();
     QMap<QString, QDateTime> getJobDeadlines() const { return jobDeadlines; }
     QSet<QString> activeAssignments;
@@ -155,6 +157,7 @@ private:
 
     QMap<QString, FlagData> flags;
     QMap<QString, QDateTime> jobDeadlines;
+    QMap<QString, QMap<QString, QString>> iniData;
 
     // Status tracking
     QStack<QString> statusHistory;


### PR DESCRIPTION
## Summary
- include `QTableWidget` in `Assignments` header
- expose `iniData` and getter in `CyberDom` so dialogs can access script data

## Testing
- `cmake ..` *(fails: Could NOT find Qt6Multimedia)*

------
https://chatgpt.com/codex/tasks/task_e_684b819072988320bb38c2d72f47bf9f