### PR TITLE
Fix constructor block in cyberdom.cpp

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -106,6 +106,7 @@ CyberDom::CyberDom(QWidget *parent)
         qDebug() << "[INFO] Loaded saved variables from" << cdsPath;
     } else {
         qDebug() << "[INFO] No .cds found (or failed to load) at" << cdsPath;
+    }
 
     // Initialize the internal clock with the current system time
     QSettings settings(settingsFile, QSettings::IniFormat);


### PR DESCRIPTION
## Summary
- close the conditional in the CyberDom constructor

## Testing
- `g++ -std=c++11 -fsyntax-only cyberdom.cpp` *(fails: `QMainWindow: No such file or directory`)*