### PR TITLE
Fix destructor compile error

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -26,6 +26,7 @@
 #include <QSettings>
 #include <QProcess>
 #include <QFile>
+#include <QTextStream>
 #include <QRandomGenerator>
 #include <cstdlib>
 #include <ctime>
@@ -164,7 +165,7 @@ CyberDom::~CyberDom()
     if (scriptParser) {
         QString cdsPath = currentIniFile;
         cdsPath.replace(".ini", ".cds");
-        scriptParser->saveToCDS(cdsPath);
+        saveVariablesToCDS(cdsPath);
     }
 
     delete ui;
@@ -2102,4 +2103,24 @@ void CyberDom::loadQuestionAnswers() {
         questionAnswers[key] = settings.value(key).toString();
     }
     settings.endGroup();
+}
+
+void CyberDom::saveVariablesToCDS(const QString &cdsPath) {
+    if (!scriptParser)
+        return;
+
+    QFile file(cdsPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "[CyberDom] Failed to write .cds:" << cdsPath
+                   << "-" << file.errorString();
+        return;
+    }
+
+    QTextStream out(&file);
+    const auto &vars = scriptParser->getScriptData().stringVariables;
+    for (auto it = vars.constBegin(); it != vars.constEnd(); ++it) {
+        out << it.key() << "=" << it.value() << "\n";
+    }
+
+    file.close();
 }

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -116,6 +116,9 @@ private:
     QString loadIniFilePath();
     void initializeIniFile();
 
+    // Save variables from the script parser to a .cds file
+    void saveVariablesToCDS(const QString &cdsPath);
+
     // Script initialization
     void loadAndParseScript(const QString &filePath);
     void applyScriptSettings();


### PR DESCRIPTION
## Summary
- remove use of non-existent ScriptParser::saveToCDS
- add local routine to persist variables in CDS format
- expose new helper in header

## Testing
- `cmake .` *(fails: Could not find Qt package)*