### PR TITLE
Fix question dialog usage

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -2001,8 +2001,11 @@ void CyberDom::runProcedure(const QString &procedureName) {
                 // Apply variable replacement to question text
                 questionData.phrase = replaceVariables(questionData.phrase);
 
+                // Build a list containing this single question
+                QList<QuestionDefinition> questions{questionData};
+
                 // Create and show the question dialog
-                QuestionDialog dialog(questionData, this);
+                QuestionDialog dialog(questions, this);
                 dialog.setWindowTitle("Question");
 
                 // Show the dialog and get result


### PR DESCRIPTION
## Summary
- build a `QList<QuestionDefinition>` from question data in `runProcedure`
- pass that list to the `QuestionDialog` constructor

## Testing
- `cmake ..` *(fails: Qt6Multimedia missing)*