### PR TITLE
Remove obsolete question cancellation code

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -2029,12 +2029,6 @@ void CyberDom::runProcedure(const QString &procedureName) {
                             runProcedure(procedureName);
                         }
                     }
-                } else {
-                    // User canceled - check if we have a NoInputProcedure
-                    if (!questionData.noInputProcedure.isEmpty()) {
-                        qDebug() << "[DEBUG] Running NoInputProcedure:" << questionData.noInputProcedure;
-                        runProcedure(questionData.noInputProcedure);
-                    }
                 }
 
             } else if (key.startsWith("set#", Qt::CaseInsensitive)) {


### PR DESCRIPTION
## Summary
- drop unused `noInputProcedure` path when a question is cancelled

## Testing
- `qmake CyberDom.pro` *(fails: Unknown module(s) in QT: multimedia)*

------
https://chatgpt.com/codex/tasks/task_e_68536af3046c8320ac86f99e00fdbd12