### PR TITLE
Implement AddClothing overloads

### DIFF
--- a/addclothing.cpp
+++ b/addclothing.cpp
@@ -31,6 +31,24 @@ AddClothing::AddClothing(const QString &clothingType, QWidget *parent)
     ui->tw_addcloth->verticalHeader()->setVisible(false);
 }
 
+AddClothing::AddClothing(QWidget *parent,
+                         const QString &selectedType,
+                         const QStringList &attributes)
+    : AddClothing(selectedType, parent)
+{
+    Q_UNUSED(attributes);
+}
+
+AddClothing::AddClothing(QWidget *parent,
+                         const QString &selectedType,
+                         const ClothingItem &item,
+                         const QStringList &attributes)
+    : AddClothing(selectedType, parent)
+{
+    Q_UNUSED(item);
+    Q_UNUSED(attributes);
+}
+
 AddClothing::~AddClothing()
 {
     delete ui;

--- a/addclothing.h
+++ b/addclothing.h
@@ -21,13 +21,15 @@ public:
     explicit AddClothing(const QString &clothingType, QWidget *parent = nullptr);
     
     // Constructor with attributes list
-    // explicit AddClothing(QWidget *parent, const QString &selectedType, const QStringList &attributes);
-    
-    // // Constructor for editing an existing clothing item
-    // AddClothing(QWidget *parent, const QString &selectedType, const ClothingItem &item);
-    
-    // // Constructor for editing with provided attributes
-    // AddClothing(QWidget *parent, const QString &selectedType, const ClothingItem &item, const QStringList &attributes);
+    AddClothing(QWidget *parent,
+                const QString &selectedType,
+                const QStringList &attributes);
+
+    // Constructor for editing an existing clothing item with attributes
+    AddClothing(QWidget *parent,
+                const QString &selectedType,
+                const ClothingItem &item,
+                const QStringList &attributes);
     
     ~AddClothing();
 


### PR DESCRIPTION
## Summary
- declare overloads for AddClothing taking selected type and attributes
- implement the new overloads delegating to the existing constructor

## Testing
- `g++ -fPIC -c reportclothing.cpp -std=c++14 -I. -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/x86_64-linux-gnu/qt5/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork`