### PR TITLE
Fix constructor declarations and remove duplicates

### DIFF
--- a/addclothing.cpp
+++ b/addclothing.cpp
@@ -68,18 +68,3 @@ void AddClothing::setupTable(const QString &clothingType, const QStringList &att
     ui->tw_addcloth->horizontalHeader()->setStretchLastSection(true);
     ui->tw_addcloth->verticalHeader()->setVisible(false);
 }
-
-AddClothing::AddClothing(QWidget *parent,
-                         const QString &selectedType,
-                         const ClothingItem &item,
-                         const QStringList &attributes)
-    : AddClothing(selectedType, parent)
-{
-    Q_UNUSED(item);
-    Q_UNUSED(attributes);
-}
-
-AddClothing::~AddClothing()
-{
-    delete ui;
-}

--- a/addclothing.h
+++ b/addclothing.h
@@ -18,7 +18,8 @@ class AddClothing : public QDialog
 
 public:
     // Constructor for creating a new clothing item
-    explicit AddClothing(const QString &clothingType, QWidget *parent = nullptr);
+    explicit AddClothing(QWidget *parent,
+                         const QString &clothingType);
     
     // Constructor with attributes list
     AddClothing(QWidget *parent,


### PR DESCRIPTION
## Summary
- align `AddClothing` constructor declarations in the header with the implementation
- remove duplicate constructor and destructor definitions from `addclothing.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by `QT`)*