### PR TITLE
Fix AddClothing slot implementations

### DIFF
--- a/addclothing.cpp
+++ b/addclothing.cpp
@@ -2,12 +2,17 @@
 #include "ui_addclothing.h"
 
 #include <QTableWidgetItem>
+#include <QMessageBox>
+#include <QDialogButtonBox>
 
 AddClothing::AddClothing(QWidget *parent, const QString &clothingType)
     : QDialog(parent)
     , ui(new Ui::AddClothing)
 {
     ui->setupUi(this);
+    isEditMode = false;
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &AddClothing::on_buttonBox_accepted);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     setupTable(clothingType, {"Colour", "Style", "Description"});
 }
 
@@ -17,6 +22,9 @@ AddClothing::AddClothing(QWidget *parent, const QString &clothingType,
     , ui(new Ui::AddClothing)
 {
     ui->setupUi(this);
+    isEditMode = false;
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &AddClothing::on_buttonBox_accepted);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     setupTable(clothingType, attributes);
 }
 
@@ -26,6 +34,9 @@ AddClothing::AddClothing(QWidget *parent, const QString &clothingType,
     , ui(new Ui::AddClothing)
 {
     ui->setupUi(this);
+    isEditMode = true;
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &AddClothing::on_buttonBox_accepted);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     setupTable(clothingType, attributes, &item);
 }
 
@@ -67,4 +78,41 @@ void AddClothing::setupTable(const QString &clothingType, const QStringList &att
 
     ui->tw_addcloth->horizontalHeader()->setStretchLastSection(true);
     ui->tw_addcloth->verticalHeader()->setVisible(false);
+}
+
+void AddClothing::onTypeChanged(int index)
+{
+    Q_UNUSED(index);
+    // Placeholder for future type-based behaviour
+}
+
+void AddClothing::on_buttonBox_accepted()
+{
+    QString type = ui->tw_addcloth->item(0, 1)->text().trimmed();
+    QString name = ui->tw_addcloth->item(1, 1)->text().trimmed();
+
+    if (name.isEmpty()) {
+        QMessageBox::warning(this, tr("Missing Name"),
+                             tr("Please enter a name for the clothing item."));
+        return;
+    }
+
+    ClothingItem item(name, type);
+    for (int row = 2; row < ui->tw_addcloth->rowCount(); ++row) {
+        QTableWidgetItem *attrItem = ui->tw_addcloth->item(row, 0);
+        QTableWidgetItem *valueItem = ui->tw_addcloth->item(row, 1);
+        if (!attrItem || !valueItem)
+            continue;
+        QString attrName = attrItem->text();
+        QString attrValue = valueItem->text().trimmed();
+        if (!attrValue.isEmpty())
+            item.addAttribute(attrName, attrValue);
+    }
+
+    if (isEditMode)
+        emit clothingItemEdited(item);
+    else
+        emit clothingItemAdded(item);
+
+    accept();
 }

--- a/addclothing.h
+++ b/addclothing.h
@@ -47,8 +47,8 @@ private slots:
 private:
     Ui::AddClothing *ui;
     QMap<QString, QStringList> clothingTypes;
+    bool isEditMode = false; // True when editing an existing item
     // QString clothingType;
-    // bool isEditMode;
     // ClothingItem existingItem;
     // QLineEdit *nameEdit; // Line edit for clothing item name
     // QStringList providedAttributes; // Attributes provided from outside


### PR DESCRIPTION
## Summary
- implement missing `on_buttonBox_accepted` and `onTypeChanged` slots
- connect dialog button signals to new slot
- track edit mode to know which signal to emit

## Testing
- `cmake ..` *(fails: Could not find Qt package)*