### PR TITLE
Fix duplicated include in cyberdom.cpp

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -16,8 +16,7 @@
 #include "rules.h" // Include the header for Rules UI
 #include "listflags.h" // Include the header for the ListFlags UI
 #include "setflags.h" // Include the header for the SetFlags UI
-#include "deleteassignments.h" // Include the header for the DeleteAssignments UI
-#include "askpunishment.h"
+#include "deleteassignments.h" // Include the header for DeleteAssignments UI
 #include "clothingitem.h"
 #include "questiondialog.h"
 


### PR DESCRIPTION
## Summary
- remove redundant `#include "askpunishment.h"`
- shorten DeleteAssignments comment

## Testing
- `qmake CyberDom.pro -o Makefile`
- `make -j2` *(fails: QAudioOutput ctor mismatch)*