### PR TITLE
Implement session persistence

### DIFF
--- a/cyberdom.h
+++ b/cyberdom.h
@@ -119,6 +119,10 @@ private:
     // Save variables from the script parser to a .cds file
     void saveVariablesToCDS(const QString &cdsPath);
 
+    // Session management
+    bool loadSessionData(const QString &path);
+    void saveSessionData(const QString &path) const;
+
     // Script initialization
     void loadAndParseScript(const QString &filePath);
     void applyScriptSettings();
@@ -143,6 +147,7 @@ private:
     QDateTime internalClock;
     QString currentIniFile;
     QString settingsFile;
+    QString sessionFilePath;
     QString currentStatus;
 
     Rules *rulesDialog;


### PR DESCRIPTION
## Summary
- add `.cdt` session load/save helpers
- load session on start and save it on exit
- track session path in `CyberDom`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file)*
- `qmake CyberDom.pro`
- `make -j4` *(fails: no matching function for call to `QAudioOutput`)*