### PR TITLE
Fix assignments refresh after delete

### DIFF
--- a/assignments.cpp
+++ b/assignments.cpp
@@ -27,8 +27,8 @@ Assignments::Assignments(QWidget *parent, CyberDom *app)
     if (!mainApp) {
         qDebug() << "[ERROR] mainApp is NULL in Assignments!";
     } else {
-        connect(mainApp, &CyberDom::jobListUpdated, this, &Assignments::populateJobList);
-        qDebug() << "[DEBUG] Connected Assignments to CyberDom's jobListUpdated Signal!";
+        // The connection to jobListUpdated is made in CyberDom::openAssignmentsWindow
+        qDebug() << "[DEBUG] Assignments constructed";
     }
 }
 
@@ -420,29 +420,8 @@ void Assignments::on_btn_Delete_clicked()
         return;
     }
 
-    // Remove the assignment from active assignments
-    mainApp->activeAssignments.remove(assignmentName);
-    mainApp->removeJobDeadline(assignmentName);
-
-    // Clear any related flags
-    QString startFlagName = (isPunishment ? "punishment_" : "job_") + assignmentName + "_started";
-    mainApp->removeFlag(startFlagName);
-
-    // Reset status if needed
-    QString statusFlagName = (isPunishment ? "punishment_" : "job_") + assignmentName + "_prev_status";
-    QSettings settings(settingsFile, QSettings::IniFormat);
-    QString prevStatus = settings.value("Assignments/" + statusFlagName, "").toString();
-
-    if (!prevStatus.isEmpty()) {
-        mainApp->updateStatus(prevStatus);
-        settings.remove("Assignments/" + statusFlagName);
-    }
-
-    // Execute delete procedure if specified
-    if (details.contains("DeleteProcedure")) {
-        // Call the procedure handling if implemented
-        // mainApp->executeProcedure(details["DeleteProcedure"]);
-    }
+    // Delegate the removal logic to CyberDom so the jobListUpdated signal is emitted
+    mainApp->deleteAssignment(assignmentName, isPunishment);
 
     QMessageBox::information(this, assignmentType + " Deleted", assignmentType + " " + assignmentName + " has been deleted.");
 

--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -1827,6 +1827,48 @@ void CyberDom::markAssignmentDone(const QString &assignmentName, bool isPunishme
     emit jobListUpdated();
 }
 
+void CyberDom::deleteAssignment(const QString &assignmentName, bool isPunishment)
+{
+    QString sectionPrefix = isPunishment ? "punishment-" : "job-";
+    QString sectionName = sectionPrefix + assignmentName;
+
+    bool sectionFound = false;
+    QMap<QString, QString> details;
+    for (auto it = iniData.constBegin(); it != iniData.constEnd(); ++it) {
+        if (it.key().toLower() == sectionName.toLower()) {
+            sectionFound = true;
+            details = it.value();
+            break;
+        }
+    }
+
+    if (!sectionFound) {
+        qDebug() << "[WARNING] Section not found for deleted assignment: " << sectionName;
+        return;
+    }
+
+    activeAssignments.remove(assignmentName);
+    jobDeadlines.remove(assignmentName);
+
+    QString startFlagName = (isPunishment ? "punishment_" : "job_") + assignmentName + "_started";
+    removeFlag(startFlagName);
+
+    QString statusFlagName = (isPunishment ? "punishment_" : "job_") + assignmentName + "_prev_status";
+    QSettings settings(settingsFile, QSettings::IniFormat);
+    QString prevStatus = settings.value("Assignments/" + statusFlagName, "").toString();
+    if (!prevStatus.isEmpty()) {
+        updateStatus(prevStatus);
+        settings.remove("Assignments/" + statusFlagName);
+    }
+
+    if (details.contains("DeleteProcedure")) {
+        // Placeholder for procedure execution
+        // runProcedure(details["DeleteProcedure"]);
+    }
+
+    emit jobListUpdated();
+}
+
 bool CyberDom::isFlagSet(const QString &flagName) const {
     return flags.contains(flagName);
 }


### PR DESCRIPTION
## Summary
- avoid duplicate connections to `jobListUpdated` by removing connection in Assignments constructor
- emit job list update through new `CyberDom::deleteAssignment` when deleting
- call `CyberDom::deleteAssignment` from `Assignments` delete button handler