### PR TITLE
Fix ReportClothing type loading

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -329,7 +329,7 @@ void CyberDom::openAskInstructionsDialog()
 
 void CyberDom::openReportClothingDialog()
 {
-    ReportClothing *reportClothingDialog = new ReportClothing(this);
+    ReportClothing *reportClothingDialog = new ReportClothing(this, scriptParser);
     
     // Display the dialog
     if (reportClothingDialog->exec() == QDialog::Accepted) {


### PR DESCRIPTION
## Summary
- pass `scriptParser` pointer when creating `ReportClothing` dialog so that clothing types from the script are available

## Testing
- `cmake -S . -B build`