### PR TITLE
Add dynamic report menu

### DIFF
--- a/ScriptData.h
+++ b/ScriptData.h
@@ -6,6 +6,7 @@
 #include <QMap>
 #include <QDateTime>
 #include <QStack>
+#include <QSet>
 
 enum class CaseMode {
     All,

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QTimer>
 #include <QDateTime>
+#include <QMenu>
 #include <QMap>
 #include <QString>
 #include <QStringList>
@@ -177,6 +178,8 @@ private:
     QTimer *flagTimer;
 
     bool testMenuEnabled = false;
+    QMenu *reportMenu = nullptr;
+
     bool isPunishment = false;
 
     QList<ClothingItem> clothingInventory;
@@ -207,6 +210,7 @@ private:
     void executeStatusEntryProcedures(const QString &statusName);
     void updateStatusDisplay();
 
+    void populateReportMenu();
 private slots:
     void applyTimeToClock(int days, int hours, int minutes, int seconds);
     void openAboutDialog();
@@ -215,6 +219,7 @@ private slots:
     void openReportClothingDialog();
     void setupMenuConnections();
     void openAskPunishmentDialog();
+    void openReport(const QString &name);
     void openChangeMeritsDialog();
     void openChangeStatusDialog();
     void openLaunchJobDialog();

--- a/cyberdom.ui
+++ b/cyberdom.ui
@@ -136,7 +136,7 @@
      <string>Communication</string>
     </property>
     <addaction name="actionAsk_Permission"/>
-    <addaction name="actionReport"/>
+    <addaction name="menuReport"/>
     <addaction name="actionReport_Clothing"/>
     <addaction name="actionCofess"/>
     <addaction name="actionAsk_for_Clothing_Instructions"/>
@@ -225,11 +225,11 @@
     <string>Ask Permission</string>
    </property>
   </action>
-  <action name="actionReport">
-   <property name="text">
+  <widget class="QMenu" name="menuReport">
+   <property name="title">
     <string>Report</string>
    </property>
-  </action>
+  </widget>
   <action name="actionReport_Clothing">
    <property name="text">
     <string>Report Clothing</string>


### PR DESCRIPTION
## Summary
- convert `actionReport` entry into a submenu `menuReport`
- add `reportMenu` pointer and `populateReportMenu()`
- build the report menu at runtime from parsed script data
- open reports by calling the matching procedure
- include `<QSet>` in `ScriptData.h` for compilation

## Testing
- `qmake CyberDom.pro`
- `make -j$(nproc)` *(fails: QAudioOutput constructor errors)*