### PR TITLE
Include QAction in cyberdom.cpp

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -21,6 +21,7 @@
 #include "questiondialog.h"
 
 #include <QFileDialog>
+#include <QAction>
 #include <QMessageBox>
 #include <QSettings>
 #include <QDebug>


### PR DESCRIPTION
## Summary
- include QAction in `cyberdom.cpp`
- verify qmake build (fails due to unrelated build errors)

## Testing
- `qmake CyberDom.pro -o Makefile`
- `make -j$(nproc)`