### PR TITLE
Improve audio playback error handling

### DIFF
--- a/cyberdom.h
+++ b/cyberdom.h
@@ -209,6 +209,7 @@ private:
     void updateAvailableActions();
     void executeStatusEntryProcedures(const QString &statusName);
     void updateStatusDisplay();
+    void playSoundSafe(const QString &filePath);
 
     void populateReportMenu();
 private slots:


### PR DESCRIPTION
## Summary
- add helper to safely play audio and log failures
- use helper in `updateInternalClock` timers
- use helper for procedure sounds

## Testing
- `cmake ..`
- `make -j$(nproc)`