### PR TITLE
Fix README and audio error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ tail -f debug_output.log
 ```
 
 Each menu entry will be listed with a `[ReportMenu]` prefix as it is created. A crash after a specific entry often indicates a problem in the script definition for that report.
-=======
+
+For additional help, review the example scripts included with the project and open an issue if problems persist.

--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -1913,14 +1913,14 @@ void CyberDom::markAssignmentDone(const QString &assignmentName, bool isPunishme
 void CyberDom::playSoundSafe(const QString &filePath) {
     auto player = new QMediaPlayer(this);
     connect(player,
-            QOverload<QMediaPlayer::Error>::of(&QMediaPlayer::error), this,
-            [player, filePath](QMediaPlayer::Error error) {
+            &QMediaPlayer::errorOccurred,
+            this,
+            [player, filePath](QMediaPlayer::Error error, const QString &errorString) {
                 if (error != QMediaPlayer::NoError) {
-                    qWarning() << "[Audio] Failed to play" << filePath << ":"
-                               << player->errorString();
+                    qWarning() << "[Audio] Failed to play" << filePath << ":" << errorString;
                 }
             });
-    player->setMedia(QUrl::fromLocalFile(filePath));
+    player->setSource(QUrl::fromLocalFile(filePath));
     player->play();
     if (player->error() != QMediaPlayer::NoError) {
         qWarning() << "[Audio] Failed to start playback for" << filePath << ":"


### PR DESCRIPTION
## Summary
- clean up truncated README section
- update sound playback for Qt6 `QMediaPlayer`

## Testing
- `cmake -S . -B build`