### PR TITLE
Implement report execution

### DIFF
--- a/cyberdom.h
+++ b/cyberdom.h
@@ -186,6 +186,7 @@ private:
 
     // Procedure handling
     void runProcedure(const QString &procedureName);
+    void executeReport(const QString &name);
 
     struct TimerInstance {
         QString name;


### PR DESCRIPTION
## Summary
- add `executeReport()` for interpreting report definitions
- invoke `executeReport()` in `openReport()` instead of manual procedure call

## Testing
- `cmake ..`
- `make`