### PR TITLE
Add Debian Qt prerequisites and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 CyberDom-Qt is a Qt-based graphical interface for running CyberDom training scripts. The application guides the user through tasks defined in a script while handling jobs, punishments and rewards.
 
+## Prerequisites
+
+Install the following Qt packages on Debian/Ubuntu:
+
+```bash
+sudo apt-get install qtbase5-dev qt5-qmake qtchooser libqt5multimedia5-dev
+```
+
+A helper script `setup-debian.sh` is provided to automate this. After installing the packages, rerun `cmake ..` in the `build` directory if you configured the project before installing dependencies.
+
 ## Build
 
 Ensure a Qt development environment is available and CMake 3.14 or newer is installed:

--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+sudo apt-get update
+sudo apt-get install -y \
+    qtbase5-dev qt5-qmake qtchooser libqt5multimedia5-dev
+
+echo "Qt packages installed. Run 'cmake ..' inside build directory again."
+


### PR DESCRIPTION
## Summary
- document required Qt packages
- provide `setup-debian.sh` helper
- mention rerunning `cmake` after installing dependencies

## Testing
- `cmake ..`
- `make -j$(nproc)`