### PR TITLE
Fix missing UI elements for CyberDom main window

### DIFF
--- a/cyberdom.ui
+++ b/cyberdom.ui
@@ -10,9 +10,73 @@
     <height>600</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>CyberDom</string>
-  </property>
+   <property name="windowTitle">
+    <string>CyberDom</string>
+   </property>
+   <widget class="QWidget" name="centralwidget">
+    <widget class="QLabel" name="clockLabel">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>20</y>
+       <width>111</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>00:00:00</string>
+     </property>
+    </widget>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>510</y>
+       <width>761</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="lbl_Status">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>70</y>
+       <width>200</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Status:</string>
+     </property>
+    </widget>
+    <widget class="QTextBrowser" name="textBrowser">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>110</y>
+       <width>761</width>
+       <height>351</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="lbl_Merits">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>470</y>
+       <width>200</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Merits:</string>
+     </property>
+    </widget>
+   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
## Summary
- add `centralwidget` to `cyberdom.ui`
- include widgets used by code: `clockLabel`, `progressBar`, `lbl_Status`, `textBrowser`, `lbl_Merits`

## Testing
- `cmake .. && make -j$(nproc)`