### PR TITLE
Add dynamic confess menu support

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -56,6 +56,10 @@ CyberDom::CyberDom(QWidget *parent)
     if (reportMenu)
         connect(this, &CyberDom::destroyed, reportMenu, &QMenu::clear);
 
+    confessMenu = ui->menuConfess;
+    if (confessMenu)
+        connect(this, &CyberDom::destroyed, confessMenu, &QMenu::clear);
+
     // Connect the menuAssignments action to the slot function
     connect(ui->actionAssignments, &QAction::triggered, this, &CyberDom::openAssignmentsWindow);
 
@@ -210,6 +214,8 @@ CyberDom::~CyberDom()
 
     if (reportMenu)
         reportMenu->clear();
+    if (confessMenu)
+        confessMenu->clear();
 
     delete ui;
     delete scriptParser;
@@ -371,6 +377,12 @@ void CyberDom::openReport(const QString &name)
     executeReport(name);
 }
 
+void CyberDom::openConfession(const QString &name)
+{
+    qDebug() << "[ConfessMenu] Selected confession:" << name;
+    // Placeholder for future implementation
+}
+
 void CyberDom::populateReportMenu()
 {
     // Refresh the pointer each time in case the UI was recreated
@@ -403,6 +415,31 @@ void CyberDom::populateReportMenu()
         reportMenu->addAction(act);
         connect(act, &QAction::triggered, this, [this, name = rep.name]() {
             openReport(name);
+        });
+    }
+}
+
+void CyberDom::populateConfessMenu()
+{
+    confessMenu = ui->menuConfess;
+    if (!confessMenu)
+        return;
+
+    confessMenu->clear();
+
+    if (!scriptParser)
+        return;
+
+    const auto confessions = scriptParser->getConfessionSections();
+    for (const auto &conf : confessions) {
+        if (!conf.showInMenu)
+            continue;
+
+        QString label = conf.title.isEmpty() ? conf.name : conf.title;
+        QAction *act = new QAction(label, confessMenu);
+        confessMenu->addAction(act);
+        connect(act, &QAction::triggered, this, [this, name = conf.name]() {
+            openConfession(name);
         });
     }
 }
@@ -1266,6 +1303,7 @@ void CyberDom::applyScriptSettings() {
     }
 
     populateReportMenu();
+    populateConfessMenu();
 }
 
 void CyberDom::setupInitialStatus() {

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -179,6 +179,7 @@ private:
 
     bool testMenuEnabled = false;
     QMenu *reportMenu = nullptr;
+    QMenu *confessMenu = nullptr;
 
     bool isPunishment = false;
 
@@ -213,6 +214,7 @@ private:
     void playSoundSafe(const QString &filePath);
 
     void populateReportMenu();
+    void populateConfessMenu();
 private slots:
     void applyTimeToClock(int days, int hours, int minutes, int seconds);
     void openAboutDialog();
@@ -231,6 +233,7 @@ private slots:
     void openListFlagsDialog();
     void openSetFlagsDialog();
     void openDeleteAssignmentsDialog();
+    void openConfession(const QString &name);
     void resetApplication();
     void updateMerits(int newMerits);
     void checkPunishments();

--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -3675,6 +3675,10 @@ QList<ClothTypeSection> ScriptParser::getClothTypeSections() const {
     return scriptData.clothingTypes.values();
 }
 
+QList<ConfessionDefinition> ScriptParser::getConfessionSections() const {
+    return scriptData.confessions.values();
+}
+
 QuestionSection ScriptParser::getQuestion(const QString &name) const {
     return scriptData.questions.value(name, QuestionDefinition());
 }

--- a/scriptparser.h
+++ b/scriptparser.h
@@ -34,6 +34,7 @@ public:
     QList<JobDefinition> getJobSections() const;
     QList<PunishmentDefinition> getPunishmentSections() const;
     QList<ClothingTypeDefinition> getClothTypeSections() const;
+    QList<ConfessionDefinition> getConfessionSections() const;
     QuestionDefinition getQuestion(const QString &name) const;
     void setVariable(const QString &name, const QString &value);
 


### PR DESCRIPTION
## Summary
- expose parsed confession sections in ScriptParser
- track `confessMenu` in CyberDom
- populate the Confess submenu using confession sections
- log the selected confession when triggered

## Testing
- `cmake ..`
- `make -j$(nproc)`