### PR TITLE
Fix permissions rules dialog listing

### DIFF
--- a/rules.cpp
+++ b/rules.cpp
@@ -1,45 +1,58 @@
 #include "rules.h"
 #include "ui_rules.h"
+#include "cyberdom.h"
 
 Rules::Rules(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::Rules)
 {
     ui->setupUi(this);
+    connect(this, &QDialog::finished, this, &Rules::resetDialog);
 }
 
 void Rules::updateRulesDialog(RuleCategory category)
 {
-    // Set the title for the lbl_Permission
+    CyberDom *mainWin = qobject_cast<CyberDom *>(parent());
+
+    ui->lw_Permissions->clear();
+    ui->lbl_Permission->clear();
+
     switch (category) {
     case Permissions:
-        ui->lbl_Permission->setText("Permissions Rules");
-        ui->lbl_Permission->clear();
-        ui->lw_Permissions->addItems({"Permission A", "Permission B", "Permission C"});
+        ui->lbl_Permission->setText("ask Permission to:");
+        if (mainWin) {
+            ScriptParser *parser = mainWin->getScriptParser();
+            if (parser) {
+                const auto &perms = parser->getScriptData().permissions;
+                QStringList items;
+                for (const auto &perm : perms) {
+                    if (!perm.title.isEmpty())
+                        items << perm.title;
+                    else
+                        items << perm.name;
+                }
+                ui->lw_Permissions->addItems(items);
+            }
+        }
         break;
     case Reports:
         ui->lbl_Permission->setText("Reports Rules");
-        ui->lbl_Permission->clear();
         ui->lw_Permissions->addItems({"Report X", "Report Y", "Report Z"});
         break;
     case Confessions:
         ui->lbl_Permission->setText("Confessions Rules");
-        ui->lbl_Permission->clear();
         ui->lw_Permissions->addItems({"Confession 1", "Confession 2"});
         break;
     case Clothing:
         ui->lbl_Permission->setText("Clothing Rules");
-        ui->lbl_Permission->clear();
         ui->lw_Permissions->addItems({"Clothing Rule 1", "Clothing Rule 2"});
         break;
     case Instructions:
         ui->lbl_Permission->setText("Instructions Rules");
-        ui->lbl_Permission->clear();
         ui->lw_Permissions->addItems({"Instruction A", "Instruction B"});
         break;
     case OtherRules:
         ui->lbl_Permission->setText("Other Rules");
-        ui->lbl_Permission->clear();
         ui->lw_Permissions->addItems({"Other Rule 1", "Other Rule 2"});
         break;
     }
@@ -50,4 +63,10 @@ void Rules::updateRulesDialog(RuleCategory category)
 Rules::~Rules()
 {
     delete ui;
+}
+
+void Rules::resetDialog()
+{
+    ui->lw_Permissions->clear();
+    ui->lbl_Permission->clear();
 }

--- a/rules.h
+++ b/rules.h
@@ -30,6 +30,7 @@ private:
 
 public slots:
     void updateRulesDialog(RuleCategory category);
+    void resetDialog();
 };
 
 #endif // RULES_H


### PR DESCRIPTION
## Summary
- populate the Permissions view with permission titles from the parsed script
- keep the label text set and clear the widgets when the dialog closes

## Testing
- `cmake ..`