### PR TITLE
Fix Instructions rules listing

### DIFF
--- a/rules.cpp
+++ b/rules.cpp
@@ -91,8 +91,23 @@ void Rules::updateRulesDialog(RuleCategory category)
         }
         break;
     case Instructions:
-        ui->lbl_Permission->setText("Instructions Rules");
-        ui->lw_Permissions->addItems({"Instruction A", "Instruction B"});
+        ui->lbl_Permission->setText("always ask Instructions on how to:");
+        if (mainWin) {
+            ScriptParser *parser = mainWin->getScriptParser();
+            if (parser) {
+                const auto instructions = parser->getInstructionSections();
+                QStringList items;
+                for (const auto &instr : instructions) {
+                    if (instr.isClothing)
+                        continue;
+                    if (!instr.title.isEmpty())
+                        items << instr.title;
+                    else
+                        items << instr.name;
+                }
+                ui->lw_Permissions->addItems(items);
+            }
+        }
         break;
     case OtherRules:
         ui->lbl_Permission->setText("Other Rules");

--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -2273,6 +2273,8 @@ void ScriptParser::parseInstructionSections(const QMap<QString, QMap<QString, QS
         bool isClothing = false;
         if (sectionName.startsWith("instruction-")) {
             sectionName = sectionName.mid(QString("instruction-").length());
+        } else if (sectionName.startsWith("instructions-")) {
+            sectionName = sectionName.mid(QString("instructions-").length());
         } else if (sectionName.startsWith("clothing-")) {
             isClothing = true;
             sectionName = sectionName.mid(QString("clothing-").length());
@@ -3680,7 +3682,14 @@ QList<ConfessionDefinition> ScriptParser::getConfessionSections() const {
 }
 
 QList<InstructionDefinition> ScriptParser::getInstructionSections() const {
-    return scriptData.instructions.values();
+    QList<InstructionDefinition> result;
+    for (auto it = scriptData.instructions.constBegin(); it != scriptData.instructions.constEnd(); ++it) {
+        QString lowerName = it.key().toLower();
+        if (scriptData.rawSections.contains(QString("set-%1").arg(lowerName)))
+            continue;
+        result.append(it.value());
+    }
+    return result;
 }
 
 QuestionSection ScriptParser::getQuestion(const QString &name) const {


### PR DESCRIPTION
## Summary
- update Rules dialog instructions list
- list all instruction sections and show correct label
- parse `[Instructions-*]` sections correctly

## Testing
- `cmake ..`