### PR TITLE
Fix script version label in About dialog

### DIFF
--- a/about.cpp
+++ b/about.cpp
@@ -17,10 +17,15 @@ About::About(QWidget *parent, const QString &iniFilePath, const QString &version
     ui->lbl_PathDir->setText(iniFilePath);
     ui->lbl_ScriptName->setText(fileInfo.fileName());
 
-    // Read the version from the .ini file and update lbl_SVersionN
-    ui->lbl_SVersionN->setText(version);
+    // Pull the script version from the [General] section.  If a value was
+    // provided via the constructor, use it as a fallback.
+    scriptVersion = settings.value("General/Version", version).toString();
 
-    qDebug() << "Version read from INI:" << version; // Debugging
+    // Update the UI label displaying the script version
+    if (ui->lbl_SVersionN)
+        ui->lbl_SVersionN->setText(scriptVersion);
+
+    qDebug() << "Version read from INI:" << scriptVersion; // Debugging
 }
 
 About::~About()

--- a/about.h
+++ b/about.h
@@ -18,6 +18,7 @@ public:
 
 private:
     Ui::About *ui;
+    QString scriptVersion;
 };
 
 #endif // ABOUT_H

--- a/about.ui
+++ b/about.ui
@@ -113,10 +113,10 @@
      <pointsize>12</pointsize>
     </font>
    </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
+  <property name="text">
+    <string>Unknown</string>
+  </property>
+ </widget>
   <widget class="QLabel" name="lbl_SVersion">
    <property name="geometry">
     <rect>
@@ -150,7 +150,7 @@
     </font>
    </property>
    <property name="text">
-    <string>TextLabel</string>
+    <string>Unknown</string>
    </property>
   </widget>
   <widget class="QLabel" name="lbl_Path">


### PR DESCRIPTION
## Summary
- load script version from the `[General]` section using `QSettings`
- store the value inside `About` and show it via `lbl_SVersionN`
- set a placeholder text in the UI

## Testing
- `cmake -S . -B build`