### PR TITLE
Use default when script version missing

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -330,7 +330,7 @@ void CyberDom::openAboutDialog()
         return;
     }
 
-    QString version = getIniValue("General", "Version"); // Retrieve version
+    QString version = getIniValue("General", "Version", "Unknown"); // Retrieve version or default
     About aboutDialog(this, currentIniFile, version); // Create the About dialog, passing the parent
     aboutDialog.exec(); // Show the dialog modally
 }


### PR DESCRIPTION
## Summary
- show a fallback `"Unknown"` script version in `openAboutDialog`

## Testing
- `cmake ..`
- `make -j$(nproc)`