### PR TITLE
Implement signin timer logic

### DIFF
--- a/cyberdom.h
+++ b/cyberdom.h
@@ -181,6 +181,8 @@ private:
     // Timers
     QTimer *punishmentTimer;
     QTimer *flagTimer;
+    QTimer *signinTimer;
+    int signinRemainingSecs = 0;
 
     bool testMenuEnabled = false;
     QMenu *reportMenu = nullptr;
@@ -247,6 +249,8 @@ private slots:
     void updateMerits(int newMerits);
     void checkPunishments();
     void checkFlagExpiry();
+    void updateSigninTimer();
+    void onResetSigninTimer();
 };
 
 #endif // CYBERDOM_H


### PR DESCRIPTION
## Summary
- add signinTimer member variables to CyberDom
- manage signin countdown in updateStatus and updateStatusDisplay
- add slot to update and reset signin timer
- start/stop signin timer based on status data
- wire up reset button and hide timer widgets by default

## Testing
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`