### PR TITLE
Add signin event hooks

### DIFF
--- a/ScriptData.h
+++ b/ScriptData.h
@@ -460,6 +460,7 @@ struct InitSettings {
 
 struct EventSettings {
     QString firstRunProcedure;
+    QString signIn;
 };
 
 struct StatusDefinition {

--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -2775,6 +2775,9 @@ void CyberDom::onResetSigninTimer() {
         int lateMinutes = qCeil((-signinRemainingSecs) / 60.0);
         int severity = status.signinPenalty1 + lateMinutes * status.signinPenalty2;
         applyPunishment(severity, status.signinPenaltyGroup);
+        QString eventProc = scriptParser->getScriptData().events.signIn;
+        if (!eventProc.isEmpty())
+            runProcedure(eventProc);
     }
 
     signinRemainingSecs = parseTimeRangeToSeconds(status.signinIntervalMin + "," + status.signinIntervalMax);

--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -370,6 +370,8 @@ void ScriptParser::parseEventsSection(const QMap<QString, QStringList>& section)
 
     if (section.contains("FirstRun"))
         e.firstRunProcedure = section["FirstRun"].value(0);
+    if (section.contains("Signin"))
+        e.signIn = section["Signin"].value(0);
 }
 
 void ScriptParser::parseStatusSections(const QMap<QString, QMap<QString, QStringList>>& sections) {


### PR DESCRIPTION
## Summary
- handle events.SignIn in `onResetSigninTimer`
- support `events/Signin` setting in parser
- store new `signIn` field in `EventSettings`

## Testing
- `qmake6 CyberDom.pro`
- `make -j2`
- `make clean`