### PR TITLE
Fix timer label visibility & SignInInterval parsing

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -54,6 +54,7 @@ CyberDom::CyberDom(QWidget *parent)
     connect(ui->resetTimer, &QPushButton::clicked, this, &CyberDom::onResetSigninTimer);
     ui->timerLabel->hide();
     ui->resetTimer->hide();
+    ui->lbl_Timer->hide();
 
     // Ensure ScriptParser is available early
     if (!scriptParser) {
@@ -885,11 +886,13 @@ void CyberDom::updateStatus(const QString &newStatus) {
             signinTimer->start(1000);
         ui->timerLabel->show();
         ui->resetTimer->show();
+        ui->lbl_Timer->show();
     } else {
         if (signinTimer)
             signinTimer->stop();
         ui->timerLabel->hide();
         ui->resetTimer->hide();
+        ui->lbl_Timer->hide();
     }
 }
 
@@ -1452,10 +1455,12 @@ void CyberDom::updateStatusDisplay() {
         signinTimer->start(1000);
         ui->timerLabel->show();
         ui->resetTimer->show();
+        ui->lbl_Timer->show();
     } else {
         signinTimer->stop();
         ui->timerLabel->hide();
         ui->resetTimer->hide();
+        ui->lbl_Timer->hide();
     }
 }
 

--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -472,8 +472,10 @@ void ScriptParser::parseStatusSections(const QMap<QString, QMap<QString, QString
         if (entries.contains("Question"))
             status.advancedQuestions.append(entries["Question"]);
 
-        if (entries.contains("SigninInterval")) {
-            QStringList parts = entries["SigninInterval"].value(0).split(',', Qt::SkipEmptyParts);
+        if (entries.contains("SigninInterval") || entries.contains("SignInInterval")) {
+            QStringList parts = entries.contains("SigninInterval")
+                                   ? entries["SigninInterval"].value(0).split(',', Qt::SkipEmptyParts)
+                                   : entries["SignInInterval"].value(0).split(',', Qt::SkipEmptyParts);
             status.signinIntervalMin = parts.value(0).trimmed();
             status.signinIntervalMax = parts.value(1, parts.value(0)).trimmed();
         }


### PR DESCRIPTION
## Summary
- hide `lbl_Timer` whenever SignInInterval isn't defined
- show `lbl_Timer` when SignInInterval exists
- accept both `SigninInterval` and `SignInInterval` in parser

## Testing
- `qmake6`