### PR TITLE
Handle mixed-case SigninInterval keys

### DIFF
--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -472,10 +472,16 @@ void ScriptParser::parseStatusSections(const QMap<QString, QMap<QString, QString
         if (entries.contains("Question"))
             status.advancedQuestions.append(entries["Question"]);
 
-        if (entries.contains("SigninInterval") || entries.contains("SignInInterval")) {
-            QStringList parts = entries.contains("SigninInterval")
-                                   ? entries["SigninInterval"].value(0).split(',', Qt::SkipEmptyParts)
-                                   : entries["SignInInterval"].value(0).split(',', Qt::SkipEmptyParts);
+        QString signinKey;
+        for (auto keyIt = entries.constBegin(); keyIt != entries.constEnd(); ++keyIt) {
+            QString lower = keyIt.key().toLower();
+            if (lower == "signininterval" || lower == "signinininterval") {
+                signinKey = keyIt.key();
+                break;
+            }
+        }
+        if (!signinKey.isEmpty()) {
+            QStringList parts = entries[signinKey].value(0).split(',', Qt::SkipEmptyParts);
             status.signinIntervalMin = parts.value(0).trimmed();
             status.signinIntervalMax = parts.value(1, parts.value(0)).trimmed();
         }

--- a/tests/mixedcase_script.ini
+++ b/tests/mixedcase_script.ini
@@ -1,0 +1,15 @@
+[General]
+MinVersion=4
+Master=Dom
+
+[status-test1]
+signinInterval=1,2
+Title=Test1
+
+[status-test2]
+SigninInterval=3,4
+Title=Test2
+
+[status-test3]
+signinininterval=5,6
+Title=Test3

--- a/tests/signininterval_test.cpp
+++ b/tests/signininterval_test.cpp
@@ -1,0 +1,28 @@
+#include <QtTest>
+#include "../scriptparser.h"
+
+class SigninIntervalTest : public QObject {
+    Q_OBJECT
+private slots:
+    void parseMixedCase();
+};
+
+void SigninIntervalTest::parseMixedCase() {
+    ScriptParser parser;
+    QVERIFY(parser.parseScript("mixedcase_script.ini"));
+
+    auto s1 = parser.getStatus("test1");
+    QCOMPARE(s1.signinIntervalMin, QString("1"));
+    QCOMPARE(s1.signinIntervalMax, QString("2"));
+
+    auto s2 = parser.getStatus("test2");
+    QCOMPARE(s2.signinIntervalMin, QString("3"));
+    QCOMPARE(s2.signinIntervalMax, QString("4"));
+
+    auto s3 = parser.getStatus("test3");
+    QCOMPARE(s3.signinIntervalMin, QString("5"));
+    QCOMPARE(s3.signinIntervalMax, QString("6"));
+}
+
+QTEST_MAIN(SigninIntervalTest)
+#include "signininterval_test.moc"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,0 +1,7 @@
+QT += core testlib
+CONFIG += console c++17 testcase
+SOURCES += signininterval_test.cpp \
+           ../scriptparser.cpp
+HEADERS += ../scriptparser.h \
+           ../ScriptData.h
+TARGET = signininterval_test


### PR DESCRIPTION
## Summary
- parseStatusSections now searches for SigninInterval keys case-insensitively
- added simple QTest project demonstrating mixed-case key parsing

## Testing
- `qmake6 tests.pro`
- `make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen ./signininterval_test -o junit.xml -xml`
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`