### PR TITLE
Extend session persistence

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -384,12 +384,14 @@ void CyberDom::openReport(const QString &name)
     }
 
     qDebug() << "[CyberDom] Opening report:" << name;
+    reportCounts[name]++;
     executeReport(name);
 }
 
 void CyberDom::openConfession(const QString &name)
 {
     qDebug() << "[ConfessMenu] Selected confession:" << name;
+    confessionCounts[name]++;
     // Placeholder for future implementation
 }
 
@@ -2606,6 +2608,8 @@ bool CyberDom::loadSessionData(const QString &path) {
     QString script = session.value("Session/ScriptPath").toString();
     int merits = session.value("Session/Merits", 0).toInt();
     QString status = session.value("Session/Status").toString();
+    lastInstructions = session.value("Session/LastInstructions").toString();
+    lastClothingInstructions = session.value("Session/LastClothingInstructions").toString();
     QDateTime lastInternal =
         QDateTime::fromString(session.value("Session/InternalClock").toString(),
                               Qt::ISODate);
@@ -2674,6 +2678,51 @@ bool CyberDom::loadSessionData(const QString &path) {
     session.endGroup();
     session.endGroup(); // Assignments
 
+    session.beginGroup("Flags");
+    const QStringList flagGroups = session.childGroups();
+    for (const QString &fname : flagGroups) {
+        session.beginGroup(fname);
+        FlagData fd;
+        fd.name = fname;
+        fd.setTime = QDateTime::fromString(session.value("SetTime").toString(), Qt::ISODate);
+        fd.expiryTime = QDateTime::fromString(session.value("ExpiryTime").toString(), Qt::ISODate);
+        fd.text = session.value("Text").toString();
+        QString groupsStr = session.value("Groups").toString();
+        if (!groupsStr.isEmpty())
+            fd.groups = groupsStr.split(',', Qt::SkipEmptyParts);
+        flags[fname] = fd;
+        session.endGroup();
+    }
+    session.endGroup();
+
+    session.beginGroup("Answers");
+    const QStringList ansKeys = session.childKeys();
+    for (const QString &key : ansKeys) {
+        questionAnswers[key] = session.value(key).toString();
+    }
+    session.endGroup();
+
+    session.beginGroup("Counters");
+    session.beginGroup("Reports");
+    const QStringList repKeys = session.childKeys();
+    for (const QString &key : repKeys) {
+        reportCounts[key] = session.value(key).toInt();
+    }
+    session.endGroup();
+    session.beginGroup("Confessions");
+    const QStringList confKeys = session.childKeys();
+    for (const QString &key : confKeys) {
+        confessionCounts[key] = session.value(key).toInt();
+    }
+    session.endGroup();
+    session.beginGroup("Permissions");
+    const QStringList permKeys = session.childKeys();
+    for (const QString &key : permKeys) {
+        permissionCounts[key] = session.value(key).toInt();
+    }
+    session.endGroup();
+    session.endGroup(); // Counters
+
     if (script.isEmpty())
         return false;
 
@@ -2712,6 +2761,8 @@ void CyberDom::saveSessionData(const QString &path) const {
                      internalClock.toString(Qt::ISODate));
     session.setValue("Session/LastSystemTime",
                      QDateTime::currentDateTime().toString(Qt::ISODate));
+    session.setValue("Session/LastInstructions", lastInstructions);
+    session.setValue("Session/LastClothingInstructions", lastClothingInstructions);
 
     // Persist active assignments and their deadlines
     session.beginGroup("Assignments");
@@ -2742,6 +2793,46 @@ void CyberDom::saveSessionData(const QString &path) const {
     }
     session.endGroup();
     session.endGroup(); // Assignments
+
+    // Persist flags
+    session.beginGroup("Flags");
+    for (auto it = flags.constBegin(); it != flags.constEnd(); ++it) {
+        const FlagData &fd = it.value();
+        session.beginGroup(it.key());
+        session.setValue("SetTime", fd.setTime.toString(Qt::ISODate));
+        session.setValue("ExpiryTime", fd.expiryTime.toString(Qt::ISODate));
+        session.setValue("Text", fd.text);
+        session.setValue("Groups", fd.groups.join(","));
+        session.endGroup();
+    }
+    session.endGroup();
+
+    // Persist question answers
+    session.beginGroup("Answers");
+    for (auto it = questionAnswers.constBegin(); it != questionAnswers.constEnd(); ++it) {
+        session.setValue(it.key(), it.value());
+    }
+    session.endGroup();
+
+    // Persist menu usage counters
+    session.beginGroup("Counters");
+    session.beginGroup("Reports");
+    for (auto it = reportCounts.constBegin(); it != reportCounts.constEnd(); ++it) {
+        session.setValue(it.key(), it.value());
+    }
+    session.endGroup();
+    session.beginGroup("Confessions");
+    for (auto it = confessionCounts.constBegin(); it != confessionCounts.constEnd(); ++it) {
+        session.setValue(it.key(), it.value());
+    }
+    session.endGroup();
+    session.beginGroup("Permissions");
+    for (auto it = permissionCounts.constBegin(); it != permissionCounts.constEnd(); ++it) {
+        session.setValue(it.key(), it.value());
+    }
+    session.endGroup();
+    session.endGroup(); // Counters
+
     session.sync();
 
     QSettings::Status stat = session.status();

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -37,6 +37,7 @@ QT_END_NAMESPACE
 class CyberDom : public QMainWindow
 {
     Q_OBJECT
+    friend class SessionSaveLoadTest;
 
 public:
     CyberDom(QWidget *parent = nullptr);
@@ -210,6 +211,10 @@ private:
     QMap<QString, QString> questionAnswers;
     void loadQuestionAnswers();
     void saveQuestionAnswers();
+
+    QMap<QString, int> reportCounts;
+    QMap<QString, int> confessionCounts;
+    QMap<QString, int> permissionCounts;
 
     // UI update methods
     void updateStatusText();

--- a/tests/session_test.cpp
+++ b/tests/session_test.cpp
@@ -1,0 +1,52 @@
+#include <QtTest>
+#include "../cyberdom.h"
+
+class SessionSaveLoadTest : public QObject {
+    Q_OBJECT
+private slots:
+    void saveLoad();
+};
+
+void SessionSaveLoadTest::saveLoad() {
+    QString scriptPath = "tests/mixedcase_script.ini";
+    QString sessionPath = QDir::temp().absoluteFilePath("cyberdom_session_test.cdt");
+
+    // First instance - set data and save
+    CyberDom first;
+    first.loadAndParseScript(scriptPath);
+    first.lastInstructions = "Do chores";
+    first.lastClothingInstructions = "Wear uniform";
+
+    FlagData fd;
+    fd.name = "flag1";
+    fd.setTime = QDateTime::currentDateTime();
+    fd.expiryTime = fd.setTime.addSecs(60);
+    fd.text = "flag text";
+    fd.groups = {"g1","g2"};
+    first.flags.insert("flag1", fd);
+
+    first.questionAnswers["q1"] = "a1";
+    first.reportCounts["rep1"] = 2;
+    first.confessionCounts["conf1"] = 1;
+    first.permissionCounts["perm1"] = 3;
+
+    first.saveSessionData(sessionPath);
+
+    // Second instance - load
+    CyberDom second;
+    QVERIFY(second.loadSessionData(sessionPath));
+
+    QCOMPARE(second.lastInstructions, first.lastInstructions);
+    QCOMPARE(second.lastClothingInstructions, first.lastClothingInstructions);
+    QCOMPARE(second.flags.size(), first.flags.size());
+    QVERIFY(second.flags.contains("flag1"));
+    QCOMPARE(second.flags["flag1"].text, QString("flag text"));
+    QCOMPARE(second.flags["flag1"].groups, QStringList({"g1","g2"}));
+    QCOMPARE(second.questionAnswers, first.questionAnswers);
+    QCOMPARE(second.reportCounts, first.reportCounts);
+    QCOMPARE(second.confessionCounts, first.confessionCounts);
+    QCOMPARE(second.permissionCounts, first.permissionCounts);
+}
+
+QTEST_MAIN(SessionSaveLoadTest)
+#include "session_test.moc"

--- a/tests/signininterval_test.cpp
+++ b/tests/signininterval_test.cpp
@@ -9,7 +9,7 @@ private slots:
 
 void SigninIntervalTest::parseMixedCase() {
     ScriptParser parser;
-    QVERIFY(parser.parseScript("mixedcase_script.ini"));
+    QVERIFY(parser.parseScript("tests/mixedcase_script.ini"));
 
     auto s1 = parser.getStatus("test1");
     QCOMPARE(s1.signinIntervalMin, QString("1"));

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,7 +1,11 @@
-QT += core testlib
+QT += core gui widgets multimedia network testlib
 CONFIG += console c++17 testcase
+
+include(../CyberDom.pro)
+
+SOURCES -= main.cpp
+
 SOURCES += signininterval_test.cpp \
-           ../scriptparser.cpp
-HEADERS += ../scriptparser.h \
-           ../ScriptData.h
-TARGET = signininterval_test
+           session_test.cpp
+
+TARGET = cyberdom_tests


### PR DESCRIPTION
## Summary
- persist instructions, flags, answers, and counters in session files
- track menu usage counts for reports and confessions
- expose class internals for unit tests and add a new session test
- fix path for existing signin interval test

## Testing
- `qmake6 tests/tests.pro`
- `make -j$(nproc)`