### PR TITLE
Fix flag expiry config lookup

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -2168,7 +2168,7 @@ void CyberDom::checkFlagExpiry() {
                 }
 
                 // Show expiry message if defined
-                QString expireMessage = getIniValue("flag=" + flagName, "ExpireMessage");
+                QString expireMessage = getIniValue("flag-" + flagName, "ExpireMessage");
                 if (!expireMessage.isEmpty()) {
                     QMessageBox::information(this, "Flag Expired", expireMessage);
                 }


### PR DESCRIPTION
## Summary
- look up expire message in the correct INI section

## Testing
- `qmake6 CyberDom.pro && make -j$(nproc)`
- `qmake6 tests/tests.pro && make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen ./tests/runtests`