### PR TITLE
Add flag token replacement in variable parser

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -1225,6 +1225,26 @@ QString CyberDom::replaceVariables(const QString &input) const {
         result.replace(var, it.value());
     }
 
+    QString onText = getIniValue("General", "FlagOnText");
+    QString offText = getIniValue("General", "FlagOffText");
+
+    if (!onText.isEmpty() && !offText.isEmpty()) {
+        QRegularExpression rx("\\{([^\\$#][^}]*)\\}");
+        QRegularExpressionMatchIterator i = rx.globalMatch(result);
+        QString processed;
+        int lastIndex = 0;
+        while (i.hasNext()) {
+            QRegularExpressionMatch match = i.next();
+            processed += result.mid(lastIndex, match.capturedStart() - lastIndex);
+            QString name = match.captured(1).trimmed();
+            QString replacement = isFlagSet(name) ? onText : offText;
+            processed += replacement;
+            lastIndex = match.capturedEnd();
+        }
+        processed += result.mid(lastIndex);
+        result = processed;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
## Summary
- expand `CyberDom::replaceVariables` to toggle `{flag}` tokens
- use FlagOnText and FlagOffText from the General section for replacements

## Testing
- `qmake6 tests/tests.pro`
- `make`