### PR TITLE
Add qmake6 requirement note

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ make
 
 ### Tests
 
-Unit tests use the Qt Test framework. Build them with:
+Unit tests use the Qt Test framework and rely on `qmake6`. Make sure the
+`qmake6` package is installed before building:
 
 ```bash
 qmake6 tests/tests.pro && make

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,6 +1,11 @@
 QT += core gui widgets multimedia testlib
 CONFIG += c++17 console
 
+# Ensure this project is processed with Qt 6's qmake tool
+!equals(QT_MAJOR_VERSION, 6) {
+    error("tests.pro requires qmake6 from Qt 6. Please install the qmake6 package and invoke qmake6.")
+}
+
 INCLUDEPATH += ..
 
 SOURCES += \


### PR DESCRIPTION
## Summary
- clarify in README that qmake6 is required for building tests
- add check in tests.pro that errors if built with qmake < 6

## Testing
- `qmake6 --version`