### PR TITLE
Add dynamic Ask Permission menu

### DIFF
--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -72,6 +72,10 @@ CyberDom::CyberDom(QWidget *parent)
     if (confessMenu)
         connect(this, &CyberDom::destroyed, confessMenu, &QMenu::clear);
 
+    permissionMenu = ui->menuAskPermission;
+    if (permissionMenu)
+        connect(this, &CyberDom::destroyed, permissionMenu, &QMenu::clear);
+
     // Connect the menuAssignments action to the slot function
     connect(ui->actionAssignments, &QAction::triggered, this, &CyberDom::openAssignmentsWindow);
 
@@ -117,8 +121,6 @@ CyberDom::CyberDom(QWidget *parent)
     // Connect the DeleteAssignments action to a slot function
     connect(ui->actionList_and_Delete_Assignments, &QAction::triggered, this, &CyberDom::openDeleteAssignmentsDialog);
 
-    // Connect asking for permissions
-    connect(ui->actionAsk_Permission, &QAction::triggered, this, &CyberDom::openAskPermissionDialog);
 
     // Connect the Delete_Status_File action to a slot function
     connect(ui->actionDelete_Status_File, &QAction::triggered, this, &CyberDom::resetApplication);
@@ -586,6 +588,31 @@ void CyberDom::populateConfessMenu()
         confessMenu->addAction(act);
         connect(act, &QAction::triggered, this, [this, name = conf.name]() {
             openConfession(name);
+        });
+    }
+}
+
+void CyberDom::populatePermissionMenu()
+{
+    permissionMenu = ui->menuAskPermission;
+    if (!permissionMenu)
+        return;
+
+    permissionMenu->clear();
+
+    if (!scriptParser)
+        return;
+
+    const auto perms = scriptParser->getPermissionSections();
+    for (const auto &perm : perms) {
+        QString label = perm.title.isEmpty() ? perm.name : perm.title;
+        label = label.trimmed();
+        if (!label.isEmpty())
+            label[0] = label[0].toUpper();
+        QAction *act = new QAction(label, permissionMenu);
+        permissionMenu->addAction(act);
+        connect(act, &QAction::triggered, this, [this, name = perm.name]() {
+            openPermission(name);
         });
     }
 }
@@ -1496,6 +1523,7 @@ void CyberDom::applyScriptSettings() {
 
     populateReportMenu();
     populateConfessMenu();
+    populatePermissionMenu();
 }
 
 void CyberDom::setupInitialStatus() {

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -190,6 +190,7 @@ private:
     bool testMenuEnabled = false;
     QMenu *reportMenu = nullptr;
     QMenu *confessMenu = nullptr;
+    QMenu *permissionMenu = nullptr;
 
     bool isPunishment = false;
 
@@ -230,6 +231,7 @@ private:
 
     void populateReportMenu();
     void populateConfessMenu();
+    void populatePermissionMenu();
 
     int parseTimeToSeconds(const QString &timeStr) const;
     int parseTimeRangeToSeconds(const QString &range) const;

--- a/cyberdom.ui
+++ b/cyberdom.ui
@@ -163,7 +163,12 @@
       <string>Confess</string>
      </property>
     </widget>
-    <addaction name="actionAsk_Permission"/>
+    <widget class="QMenu" name="menuAskPermission">
+     <property name="title">
+      <string>Ask Permission</string>
+     </property>
+    </widget>
+    <addaction name="menuAskPermission"/>
     <addaction name="actionReport_Clothing"/>
     <addaction name="menuConfess"/>
     <addaction name="actionAsk_for_Clothing_Instructions"/>
@@ -246,11 +251,6 @@
   <action name="actionExit">
    <property name="text">
     <string>Exit</string>
-   </property>
-  </action>
-  <action name="actionAsk_Permission">
-   <property name="text">
-    <string>Ask Permission</string>
    </property>
   </action>
   <action name="actionReport_Clothing">


### PR DESCRIPTION
## Summary
- create `populatePermissionMenu` to dynamically populate Ask Permission submenu from INI
- register `permissionMenu` and populate after parsing script
- update UI to use a `menuAskPermission` QMenu instead of an action

## Testing
- `qmake6 tests/tests.pro -o tests/Makefile`
- `make -C tests -j$(nproc)` *(warnings only)*
- `QT_QPA_PLATFORM=offscreen tests/runtests`
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`