### PR TITLE
Implement MinTime logic for jobs

### DIFF
--- a/assignments.cpp
+++ b/assignments.cpp
@@ -286,7 +286,11 @@ void Assignments::on_btn_Done_clicked()
     }
 
     // Call the markAssignmentDone method in CyberDom
-    mainApp->markAssignmentDone(assignmentName, isPunishment);
+    bool completed = mainApp->markAssignmentDone(assignmentName, isPunishment);
+
+    if (!completed) {
+        return; // user finished too quickly
+    }
 
     // Select a new row if available after the refresh
     if (ui->table_Assignments->rowCount() > 0) {

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -81,7 +81,7 @@ public:
     bool isInStatusGroup(const QString &groupName);
 
     void startAssignment(const QString &assignmentName, bool isPunishment, const QString &newStatus);
-    void markAssignmentDone(const QString &assignmentName, bool isPunishment);
+    bool markAssignmentDone(const QString &assignmentName, bool isPunishment);
     void abortAssignment(const QString &assignmentName, bool isPunishment);
     void deleteAssignment(const QString &assignmentName, bool isPunishment);
 
@@ -236,6 +236,7 @@ private:
 
     int parseTimeToSeconds(const QString &timeStr) const;
     int parseTimeRangeToSeconds(const QString &range) const;
+    QString formatDuration(int seconds) const;
     int randomIntFromRange(const QString &range) const;
     void incrementUsageCount(const QString &key);
     void setDefaultDeadlineForJob(const QString &jobName);


### PR DESCRIPTION
## Summary
- enforce a minimum duration for jobs using `MinTime` and related settings
- show early-completion messages and punishments
- run optional quick procedures
- report completion status back to the UI

## Testing
- `qmake6 tests/tests.pro`
- `make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen timeout 20 ./runtests`