### PR TITLE
Add time window enforcement

### DIFF
--- a/cyberdom.h
+++ b/cyberdom.h
@@ -240,6 +240,10 @@ private:
     int randomIntFromRange(const QString &range) const;
     void incrementUsageCount(const QString &key);
     void setDefaultDeadlineForJob(const QString &jobName);
+
+    bool isTimeAllowed(const QStringList &notBefore,
+                       const QStringList &notAfter,
+                       const QList<QPair<QString, QString>> &notBetween) const;
 private slots:
     void applyTimeToClock(int days, int hours, int minutes, int seconds);
     void openAboutDialog();


### PR DESCRIPTION
## Summary
- add helper `isTimeAllowed` and check time restrictions for user actions
- skip execution of procedures, timers and reports outside allowed time

## Testing
- `qmake6 tests/tests.pro`
- `make`
- `./runtests`