### PR TITLE
Add resource handling for long-running assignments

### DIFF
--- a/assignments.h
+++ b/assignments.h
@@ -25,6 +25,7 @@ public slots:
     void on_btn_Done_clicked();
     void on_btn_Abort_clicked();
     void on_btn_Delete_clicked();
+    void updateStartButtonState();
 
 private:
     Ui::Assignments *ui;

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -50,6 +50,9 @@ public:
     QSet<QString> assignedJobs;
     QSet<QString> getActiveJobs() { return activeAssignments; }
 
+    QStringList getAssignmentResources(const QString &name, bool isPunishment) const;
+    QSet<QString> getResourcesInUse() const;
+
     const QMap<QString, QMap<QString, QString>>& getIniData() const { return iniData; }
 
     QStringList getAvailableJobs();
@@ -123,6 +126,8 @@ private:
 
     // Save variables from the script parser to a .cds file
     void saveVariablesToCDS(const QString &cdsPath);
+
+    bool isAssignmentLongRunning(const QString &name, bool isPunishment) const;
 
     // Session management
     bool loadSessionData(const QString &path);


### PR DESCRIPTION
## Summary
- parse resource values already exist; add methods in CyberDom to query resources and running state
- disable Start when selected assignment conflicts with a running one
- hook selection changes in Assignments window
- expose helper APIs for resources

## Testing
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`
- `cd tests && qmake6 tests.pro`
- `make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen ./runtests`