### PR TITLE
Implement LongRunning punishments

### DIFF
--- a/assignments.cpp
+++ b/assignments.cpp
@@ -525,5 +525,8 @@ void Assignments::updateStartButtonState()
         }
     }
 
-    ui->btn_Start->setEnabled(!conflict);
+    if (conflict || mainApp->hasActiveBlockingPunishment())
+        ui->btn_Start->setEnabled(false);
+    else
+        ui->btn_Start->setEnabled(true);
 }

--- a/cyberdom.h
+++ b/cyberdom.h
@@ -52,6 +52,7 @@ public:
 
     QStringList getAssignmentResources(const QString &name, bool isPunishment) const;
     QSet<QString> getResourcesInUse() const;
+    bool hasActiveBlockingPunishment() const;
 
     const QMap<QString, QMap<QString, QString>>& getIniData() const { return iniData; }
 

--- a/tests/punishmenttest.cpp
+++ b/tests/punishmenttest.cpp
@@ -18,6 +18,8 @@ private slots:
     void assignmentDeadline();
     void jobDefaultDeadline();
     void forbidPermission();
+    void longRunningByDay();
+    void shortPunishmentBlocks();
 
 private:
     QString sessionPath;
@@ -49,6 +51,12 @@ void PunishmentTest::initTestCase() {
     out << "[punishment-nohot]\n";
     out << "ValueUnit=once\n";
     out << "Forbid=shower\n";
+    out << "[punishment-longday]\n";
+    out << "ValueUnit=day\n";
+    out << "LongRunning=0\n";
+    out << "[punishment-short]\n";
+    out << "ValueUnit=minute\n";
+    out << "LongRunning=0\n";
     script.close();
 
     sessionPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/session.cdt";
@@ -103,6 +111,32 @@ void PunishmentTest::forbidPermission() {
     mainApp = &app;
     app.addPunishmentToAssignments("nohot");
     QVERIFY(app.isPermissionForbidden("shower"));
+}
+
+void PunishmentTest::longRunningByDay()
+{
+    QFile::remove(sessionPath);
+    CyberDom app;
+    mainApp = &app;
+    app.addPunishmentToAssignments("longday");
+    app.startAssignment("longday", true, QString());
+    QVERIFY(app.isFlagSet("punishment_longday_started"));
+    app.addJobToAssignments("feedfish");
+    app.startAssignment("feedfish", false, QString());
+    QVERIFY(app.isFlagSet("job_feedfish_started"));
+}
+
+void PunishmentTest::shortPunishmentBlocks()
+{
+    QFile::remove(sessionPath);
+    CyberDom app;
+    mainApp = &app;
+    app.addPunishmentToAssignments("short");
+    app.startAssignment("short", true, QString());
+    QVERIFY(app.isFlagSet("punishment_short_started"));
+    app.addJobToAssignments("feedfish");
+    app.startAssignment("feedfish", false, QString());
+    QVERIFY(!app.isFlagSet("job_feedfish_started"));
 }
 
 QTEST_MAIN(PunishmentTest)


### PR DESCRIPTION
## Summary
- support LongRunning punishments via new check in CyberDom
- block starting other jobs while a non-long-running punishment is active
- treat punishments with `ValueUnit=day` as long running
- add unit tests for long running detection and blocking

## Testing
- `qmake6 tests/tests.pro`
- `make`
- `QT_QPA_PLATFORM=offscreen ./runtests`