### PR TITLE
Update setup steps for Qt 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CyberDom-Qt is a Qt-based graphical interface for running CyberDom training scri
 Install the following Qt packages on Debian/Ubuntu:
 
 ```bash
-sudo apt-get install qt6-base-dev qt6-multimedia-dev qmake6
+sudo apt-get install qt6-base-dev qt6-multimedia-dev qt6-tools-dev qmake6
 ```
 
 A helper script `setup-debian.sh` is provided to automate this. After installing the packages, rerun `cmake ..` in the `build` directory if you configured the project before installing dependencies.
@@ -35,7 +35,8 @@ Unit tests use the Qt Test framework and rely on `qmake6`. Make sure the
 `qmake6` package is installed before building:
 
 ```bash
-qmake6 tests/tests.pro && make
+qmake6 tests/tests.pro
+make -C tests
 ```
 
 Run the resulting `runtests` executable to execute all tests.

--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -3,7 +3,8 @@ set -e
 
 sudo apt-get update
 sudo apt-get install -y \
-    qt6-base-dev qt6-multimedia-dev qmake6
+    qt6-base-dev qt6-multimedia-dev qt6-tools-dev qmake6
 
 echo "Qt packages installed. Run 'cmake ..' inside build directory again or use qmake6."
+echo "To build tests, execute: qmake6 tests/tests.pro && make -C tests"
 


### PR DESCRIPTION
## Summary
- document qt6-tools-dev as required package in README
- update test build instructions
- expand setup-debian.sh to install qt6-tools-dev
- note how to build tests from the setup script

## Testing
- `sudo apt-get install -y qt6-base-dev qt6-multimedia-dev qt6-tools-dev qmake6`
- `qmake6 tests/tests.pro`
- `make -C tests`