### PR TITLE
Add Procedure support to init section

### DIFF
--- a/ScriptData.h
+++ b/ScriptData.h
@@ -456,6 +456,7 @@ struct GeneralSettings {
 struct InitSettings {
     QString newStatus;
     int merits = -1;
+    QString procedure;
 };
 
 struct EventSettings {

--- a/cyberdom.cpp
+++ b/cyberdom.cpp
@@ -1819,14 +1819,21 @@ void CyberDom::initializeUiWithIniFile() {
     }
 
     if (iniData.contains("init")) {
-        int initialMerits = iniData["init"]["Merits"].toInt();
+        int initialMerits = 0;
+        if (iniData["init"].contains("Merits")) {
+            initialMerits = iniData["init"]["Merits"].toInt();
+        } else if (iniData["general"].contains("MaxMerits")) {
+            initialMerits = iniData["general"]["MaxMerits"].toInt() / 2;
+        }
         currentStatus = iniData["init"]["NewStatus"];
         updateMerits(initialMerits);
         updateStatus(currentStatus);
     }
 
     if (isFirstRun) {
-        QString firstRunProcedure = getIniValue("events", "FirstRun");
+        QString firstRunProcedure = getIniValue("init", "Procedure");
+        if (firstRunProcedure.isEmpty())
+            firstRunProcedure = getIniValue("events", "FirstRun");
         if (!firstRunProcedure.isEmpty()) {
             qDebug() << "[FirstRun] Executing startup procedure:" << firstRunProcedure;
             runProcedure(firstRunProcedure);

--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -363,6 +363,8 @@ void ScriptParser::parseInitSection(const QMap<QString, QStringList>& section) {
         int value = section["Merits"].value(0).toInt(&ok);
         if (ok) i.merits = value;
     }
+    if (section.contains("Procedure"))
+        i.procedure = section["Procedure"].value(0);
 }
 
 void ScriptParser::parseEventsSection(const QMap<QString, QStringList>& section) {


### PR DESCRIPTION
## Summary
- store init procedure in `InitSettings`
- parse `Procedure` key from `[init]`
- fallback to `[General]` half merits and run init procedure on first start
- use qmake6 to build tests successfully

## Testing
- `qmake6 tests/tests.pro`
- `make -j2`