### PR TITLE
Fix HideTime flag handling in parser

### DIFF
--- a/scriptparser.cpp
+++ b/scriptparser.cpp
@@ -671,8 +671,8 @@ void ScriptParser::parseStatusSections(const QMap<QString, QMap<QString, QString
             status.convertFromCounter += entries["Minutes!"];
         if (entries.contains("Seconds!"))
             status.convertFromCounter += entries["Seconds!"];
-        if (entries.contains("HideTime")) {
-            status.hideTime = (entries["HideTime"].first().trimmed() == "1");
+        if (entries.contains("HideTime") && !entries["HideTime"].isEmpty()) {
+            status.hideTime = entries["HideTime"].first().trimmed() == "1";
         }
 
         parseDurationControl(entries, status.duration);


### PR DESCRIPTION
## Summary
- ensure `HideTime` key is only read when it has entries

## Testing
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`
- `qmake6 tests/tests.pro` and `make`
- `QT_QPA_PLATFORM=offscreen ./runtests`