### PR TITLE
Add EventCalendarWidget with event highlighting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
     assignments.cpp
     linewriter.cpp
     calendarview.cpp
+    eventcalendarwidget.cpp
 )
 
 # Define header files
@@ -71,6 +72,7 @@ set(HEADERS
     assignments.h
     linewriter.h
     calendarview.h
+    eventcalendarwidget.h
 )
 
 # Define UI files

--- a/CyberDom.pro
+++ b/CyberDom.pro
@@ -35,7 +35,8 @@ SOURCES += \
     changestatus.cpp \
     askpunishment.cpp \
     linewriter.cpp \
-    calendarview.cpp
+    calendarview.cpp \
+    eventcalendarwidget.cpp
 
 HEADERS += \
     ScriptData.h \
@@ -63,7 +64,8 @@ HEADERS += \
     setflags.h \
     deleteassignments.h \
     linewriter.h \
-    calendarview.h
+    calendarview.h \
+    eventcalendarwidget.h
 
 FORMS += \
     about.ui \

--- a/calendarview.cpp
+++ b/calendarview.cpp
@@ -1,6 +1,6 @@
 #include "calendarview.h"
 #include "ui_calendarview.h"
-#include <QCalendarWidget>
+#include "eventcalendarwidget.h"
 #include <QListWidget>
 
 CalendarView::CalendarView(CyberDom *app, QWidget *parent)
@@ -9,10 +9,13 @@ CalendarView::CalendarView(CyberDom *app, QWidget *parent)
     ui->setupUi(this);
     if (mainApp)
         events = mainApp->getCalendarEvents();
-    connect(ui->calendarWidget, &QCalendarWidget::selectionChanged, this, [this]() {
-        onDateSelected(ui->calendarWidget->selectedDate());
+
+    auto *cal = ui->calendarWidget;
+    cal->setEvents(events);
+    connect(cal, &QCalendarWidget::selectionChanged, this, [this, cal]() {
+        onDateSelected(cal->selectedDate());
     });
-    onDateSelected(ui->calendarWidget->selectedDate());
+    onDateSelected(cal->selectedDate());
 }
 
 CalendarView::~CalendarView()

--- a/calendarview.ui
+++ b/calendarview.ui
@@ -4,13 +4,20 @@
  <widget class="QDialog" name="CalendarView">
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QCalendarWidget" name="calendarWidget"/>
+    <widget class="EventCalendarWidget" name="calendarWidget"/>
    </item>
    <item>
     <widget class="QListWidget" name="listWidget"/>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>EventCalendarWidget</class>
+   <extends>QCalendarWidget</extends>
+   <header>eventcalendarwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/eventcalendarwidget.cpp
+++ b/eventcalendarwidget.cpp
@@ -1,0 +1,40 @@
+#include "eventcalendarwidget.h"
+#include <QPainter>
+
+EventCalendarWidget::EventCalendarWidget(QWidget *parent)
+    : QCalendarWidget(parent)
+{
+}
+
+void EventCalendarWidget::setEvents(const QList<CalendarEvent> &events)
+{
+    m_events = events;
+    updateCells();
+}
+
+void EventCalendarWidget::paintCell(QPainter *painter, const QRect &rect, QDate date) const
+{
+    QCalendarWidget::paintCell(painter, rect, date);
+
+    for (const CalendarEvent &ev : m_events) {
+        if (ev.start.date() <= date && date <= ev.end.date()) {
+            QColor color;
+            if (ev.type.compare(QStringLiteral("Punishment"), Qt::CaseInsensitive) == 0)
+                color = Qt::red;
+            else if (ev.type.compare(QStringLiteral("Job"), Qt::CaseInsensitive) == 0)
+                color = Qt::blue;
+            else
+                color = Qt::green;
+
+            QRect markRect = QRect(rect.left() + 2, rect.bottom() - 6, rect.width() - 4, 4);
+            painter->fillRect(markRect, color);
+
+            QFont f = painter->font();
+            f.setPointSizeF(f.pointSizeF() * 0.6);
+            painter->setFont(f);
+            painter->drawText(rect.adjusted(2, 2, -2, -8), Qt::AlignLeft | Qt::TextWordWrap, ev.title);
+            break;
+        }
+    }
+}
+

--- a/eventcalendarwidget.h
+++ b/eventcalendarwidget.h
@@ -1,0 +1,22 @@
+#ifndef EVENTCALENDARWIDGET_H
+#define EVENTCALENDARWIDGET_H
+
+#include <QCalendarWidget>
+#include "cyberdom.h"
+
+class EventCalendarWidget : public QCalendarWidget
+{
+    Q_OBJECT
+public:
+    explicit EventCalendarWidget(QWidget *parent = nullptr);
+
+    void setEvents(const QList<CalendarEvent> &events);
+
+protected:
+    void paintCell(QPainter *painter, const QRect &rect, QDate date) const override;
+
+private:
+    QList<CalendarEvent> m_events;
+};
+
+#endif // EVENTCALENDARWIDGET_H

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -34,6 +34,7 @@ SOURCES += \
     ../askpunishment.cpp \
     ../linewriter.cpp \
     ../calendarview.cpp \
+    ../eventcalendarwidget.cpp \
     punishmenttest.cpp
 
 HEADERS += \
@@ -62,7 +63,8 @@ HEADERS += \
     ../setflags.h \
     ../deleteassignments.h \
     ../linewriter.h \
-    ../calendarview.h
+    ../calendarview.h \
+    ../eventcalendarwidget.h
 
 FORMS += \
     ../about.ui \


### PR DESCRIPTION
## Summary
- add `EventCalendarWidget` subclass of QCalendarWidget
- draw event markers in calendar cells
- swap calendar widget in CalendarView and provide events
- include new files in qmake and CMake builds

## Testing
- `qmake6 CyberDom.pro`
- `make -j$(nproc)`
- `cd tests && qmake6 tests.pro`
- `make -j$(nproc)`