### PR TITLE
Add CI workflow and headless test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Qt
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          qt6-base-dev qt6-multimedia-dev qt6-tools-dev qmake6
+    - name: Build tests
+      run: |
+        qmake6 tests/tests.pro
+        make -C tests
+    - name: Run tests
+      run: QT_QPA_PLATFORM=offscreen ./tests/runtests

--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ qmake6 tests/tests.pro
 make -C tests
 ```
 
-Run the resulting `runtests` executable to execute all tests.
+Execute the tests in a headless environment:
+
+```bash
+QT_QPA_PLATFORM=offscreen ./tests/runtests
+```
+
+Alternatively you can run `make -C tests test` to build and execute the tests in one step.
 
 You can also open `CyberDom.pro` in Qt Creator and build directly from the IDE.
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -90,3 +90,9 @@ FORMS += \
 
 TARGET = runtests
 
+# Convenience target to execute the tests in headless mode
+test.target = check
+test.depends = all
+test.commands = QT_QPA_PLATFORM=offscreen ./runtests
+QMAKE_EXTRA_TARGETS += test
+


### PR DESCRIPTION
## Summary
- allow running the unit tests without a display
- document how to run tests in headless mode
- run tests in CI using qmake6 and make

## Testing
- `qmake6 tests/tests.pro`
- `make -C tests -j2`
- `QT_QPA_PLATFORM=offscreen ./tests/runtests`
- `make -C tests clean`