### PR TITLE
Add new custom calendar widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
     linewriter.cpp
     calendarview.cpp
     eventcalendarwidget.cpp
+    googlecalendarwidget.cpp
 )
 
 # Define header files
@@ -73,6 +74,7 @@ set(HEADERS
     linewriter.h
     calendarview.h
     eventcalendarwidget.h
+    googlecalendarwidget.h
 )
 
 # Define UI files

--- a/CyberDom.pro
+++ b/CyberDom.pro
@@ -36,7 +36,8 @@ SOURCES += \
     askpunishment.cpp \
     linewriter.cpp \
     calendarview.cpp \
-    eventcalendarwidget.cpp
+    eventcalendarwidget.cpp \
+    googlecalendarwidget.cpp
 
 HEADERS += \
     ScriptData.h \
@@ -65,7 +66,8 @@ HEADERS += \
     deleteassignments.h \
     linewriter.h \
     calendarview.h \
-    eventcalendarwidget.h
+    eventcalendarwidget.h \
+    googlecalendarwidget.h
 
 FORMS += \
     about.ui \

--- a/calendarview.cpp
+++ b/calendarview.cpp
@@ -1,7 +1,7 @@
 #include "calendarview.h"
 #include "ui_calendarview.h"
-#include <QCalendarWidget>
 #include <QSizePolicy>
+#include <QDate>
 
 CalendarView::CalendarView(CyberDom *app, QWidget *parent)
     : QDialog(parent), ui(new Ui::CalendarView), mainApp(app)
@@ -19,8 +19,10 @@ CalendarView::~CalendarView()
 void CalendarView::showEvent(QShowEvent *event)
 {
     QDialog::showEvent(event);
-    if (mainApp)
+    if (mainApp) {
+        ui->calendarWidget->setMonth(QDate::currentDate());
         ui->calendarWidget->setEvents(mainApp->getCalendarEvents());
+    }
 }
 
 

--- a/calendarview.ui
+++ b/calendarview.ui
@@ -4,15 +4,15 @@
  <widget class="QDialog" name="CalendarView">
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="EventCalendarWidget" name="calendarWidget"/>
+    <widget class="GoogleCalendarWidget" name="calendarWidget"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>EventCalendarWidget</class>
-   <extends>QCalendarWidget</extends>
-   <header>eventcalendarwidget.h</header>
+   <class>GoogleCalendarWidget</class>
+   <extends>QWidget</extends>
+   <header>googlecalendarwidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/googlecalendarwidget.cpp
+++ b/googlecalendarwidget.cpp
@@ -1,0 +1,106 @@
+#include "googlecalendarwidget.h"
+#include <QPainter>
+#include <QLocale>
+
+GoogleCalendarWidget::GoogleCalendarWidget(QWidget *parent)
+    : QWidget(parent), m_month(QDate::currentDate())
+{
+}
+
+void GoogleCalendarWidget::setMonth(const QDate &month)
+{
+    if (month.isValid())
+        m_month = QDate(month.year(), month.month(), 1);
+    update();
+}
+
+void GoogleCalendarWidget::setEvents(const QList<CalendarEvent> &events)
+{
+    m_events = events;
+    update();
+}
+
+void GoogleCalendarWidget::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    const int cols = 7;
+    const int headerHeight = 20;
+    const int cellWidth = width() / cols;
+    const int cellHeight = (height() - headerHeight) / 6;
+
+    // Day of week headers
+    QDate weekRef(2023,1,2); // Monday
+    for (int i = 0; i < cols; ++i) {
+        QRect rect(i * cellWidth, 0, cellWidth, headerHeight);
+        QString text = QLocale().dayName(((i + 1) % 7) + 1, QLocale::ShortFormat);
+        painter.drawText(rect, Qt::AlignCenter, text);
+    }
+
+    QDate first(m_month.year(), m_month.month(), 1);
+    int startIdx = (first.dayOfWeek() + 6) % 7; // Monday=0
+    QDate day = first.addDays(-startIdx);
+
+    for (int row = 0; row < 6; ++row) {
+        for (int col = 0; col < cols; ++col) {
+            QRect rect(col * cellWidth, headerHeight + row * cellHeight, cellWidth, cellHeight);
+            if (day.month() != m_month.month())
+                painter.fillRect(rect, palette().alternateBase());
+            else
+                painter.fillRect(rect, palette().base());
+            painter.drawRect(rect.adjusted(0,0,-1,-1));
+
+            if (day == QDate::currentDate()) {
+                painter.save();
+                painter.setPen(Qt::NoPen);
+                painter.setBrush(QColor(13,110,253,50));
+                painter.drawRect(rect.adjusted(1,1,-1,-1));
+                painter.restore();
+            }
+
+            painter.drawText(rect.adjusted(2,2,-2,-2), Qt::AlignLeft | Qt::AlignTop, QString::number(day.day()));
+
+            QVector<const CalendarEvent*> eventsForDay;
+            for (const CalendarEvent &ev : m_events) {
+                if (ev.start.date() <= day && day <= ev.end.date())
+                    eventsForDay.append(&ev);
+            }
+
+            int barHeight = 5;
+            int offset = rect.bottom() - barHeight * eventsForDay.size();
+            int index = 0;
+            for (const CalendarEvent *ev : eventsForDay) {
+                if (index >= 3)
+                    break;
+                QRect markRect(rect.left() + 2, offset + index * barHeight, rect.width() - 4, barHeight - 1);
+                painter.fillRect(markRect, colorForType(ev->type));
+                ++index;
+            }
+
+            if (!eventsForDay.isEmpty()) {
+                const CalendarEvent *ev = eventsForDay.first();
+                QFont f = painter.font();
+                f.setPointSizeF(f.pointSizeF() * 0.6);
+                painter.setFont(f);
+                painter.setPen(Qt::black);
+                painter.drawText(rect.adjusted(2, 20, -2, -8 - barHeight * (eventsForDay.size() - 1)),
+                                 Qt::AlignLeft | Qt::TextWordWrap, ev->title);
+            }
+
+            day = day.addDays(1);
+        }
+    }
+}
+
+QColor GoogleCalendarWidget::colorForType(const QString &type) const
+{
+    if (type.compare(QStringLiteral("Punishment"), Qt::CaseInsensitive) == 0)
+        return QColor(220, 53, 69);
+    if (type.compare(QStringLiteral("Job"), Qt::CaseInsensitive) == 0)
+        return QColor(13, 110, 253);
+    if (type.compare(QStringLiteral("Birthday"), Qt::CaseInsensitive) == 0)
+        return QColor(253, 126, 20);
+    return QColor(25, 135, 84);
+}

--- a/googlecalendarwidget.h
+++ b/googlecalendarwidget.h
@@ -1,0 +1,26 @@
+#ifndef GOOGLECALENDARWIDGET_H
+#define GOOGLECALENDARWIDGET_H
+
+#include <QWidget>
+#include "cyberdom.h"
+
+class GoogleCalendarWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit GoogleCalendarWidget(QWidget *parent = nullptr);
+
+    void setMonth(const QDate &month);
+    void setEvents(const QList<CalendarEvent> &events);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QColor colorForType(const QString &type) const;
+
+    QDate m_month;
+    QList<CalendarEvent> m_events;
+};
+
+#endif // GOOGLECALENDARWIDGET_H

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -35,6 +35,7 @@ SOURCES += \
     ../linewriter.cpp \
     ../calendarview.cpp \
     ../eventcalendarwidget.cpp \
+    ../googlecalendarwidget.cpp \
     punishmenttest.cpp
 
 HEADERS += \
@@ -64,7 +65,8 @@ HEADERS += \
     ../deleteassignments.h \
     ../linewriter.h \
     ../calendarview.h \
-    ../eventcalendarwidget.h
+    ../eventcalendarwidget.h \
+    ../googlecalendarwidget.h
 
 FORMS += \
     ../about.ui \


### PR DESCRIPTION
## Summary
- create `GoogleCalendarWidget` as a QWidget-based calendar
- integrate new widget into CalendarView
- update project files and tests to build the new widget

## Testing
- `qmake6 tests/tests.pro`
- `make -C tests`
- `QT_QPA_PLATFORM=offscreen ./runtests`